### PR TITLE
refactor(ubi): Removing the hardcoded 4-second wait when creating a UBI job

### DIFF
--- a/internal/computing/ubi.go
+++ b/internal/computing/ubi.go
@@ -333,6 +333,7 @@ func DoUbiTaskForK8s(c *gin.Context) {
 			return
 		}
 
+		// TODO(yejiayu): Change it to the parameters you prefer or make it a configuration file.
 		err = wait.PollImmediate(2*time.Second, 60*time.Second, func() (bool, error) {
 			pods, err := k8sService.k8sClient.CoreV1().Pods(namespace).List(context.TODO(), metaV1.ListOptions{
 				LabelSelector: fmt.Sprintf("job-name=%s", JobName),

--- a/internal/computing/ubi.go
+++ b/internal/computing/ubi.go
@@ -4,6 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/docker/docker/api/types/container"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/filswan/go-swan-lib/logs"
@@ -17,20 +26,14 @@ import (
 	"github.com/swanchain/go-computing-provider/internal/models"
 	"github.com/swanchain/go-computing-provider/util"
 	"github.com/swanchain/go-computing-provider/wallet"
-	"io"
 	batchv1 "k8s.io/api/batch/v1"
 	coreV1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net"
-	"net/http"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"time"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func DoUbiTaskForK8s(c *gin.Context) {
@@ -330,11 +333,35 @@ func DoUbiTaskForK8s(c *gin.Context) {
 			return
 		}
 
-		time.Sleep(4 * time.Second)
+		err = wait.PollImmediate(2*time.Second, 60*time.Second, func() (bool, error) {
+			pods, err := k8sService.k8sClient.CoreV1().Pods(namespace).List(context.TODO(), metaV1.ListOptions{
+				LabelSelector: fmt.Sprintf("job-name=%s", JobName),
+			})
+			if err != nil {
+				return false, err
+			}
+
+			for _, p := range pods.Items {
+				for _, condition := range p.Status.Conditions {
+					if condition.Type != corev1.PodReady && condition.Status != corev1.ConditionTrue {
+						return false, nil
+					}
+				}
+			}
+			return true, nil
+		})
+		if err != nil {
+			logs.GetLogger().Errorf("Failed waiting pods create: %v", err)
+			return
+		}
 
 		pods, err := k8sService.k8sClient.CoreV1().Pods(namespace).List(context.TODO(), metaV1.ListOptions{
 			LabelSelector: fmt.Sprintf("job-name=%s", JobName),
 		})
+		if err != nil {
+			logs.GetLogger().Errorf("Failed list ubi pods: %v", err)
+			return
+		}
 
 		var podName string
 		for _, pod := range pods.Items {


### PR DESCRIPTION
Waiting for 4 seconds is very dirty. Due to network issues or other factors, it is quite normal for the image pull or job creation to take longer than 4 seconds.