### PR TITLE
fix(cron_task): Check the case where the get Collateral balance API returns an unsuccessful status

### DIFF
--- a/internal/computing/cron_task.go
+++ b/internal/computing/cron_task.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/filswan/go-mcs-sdk/mcs/api/common/logs"
 	"github.com/gomodule/redigo/redis"
 	"github.com/robfig/cron/v3"
 	"github.com/swanchain/go-computing-provider/conf"
 	"github.com/swanchain/go-computing-provider/constants"
-	"io"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"math"
-	"net/http"
-	"strings"
-	"time"
 )
 
 type CronTask struct {
@@ -71,6 +72,11 @@ func (task *CronTask) checkCollateralBalance() {
 		err = json.Unmarshal(body, &collateral)
 		if err != nil {
 			logs.GetLogger().Errorf("json conversion failed: %+v", err)
+			return
+		}
+
+		if collateral.Status != "success" {
+			logs.GetLogger().Errorf("check collateral balance failed. status: %s, message: %s", collateral.Status, collateral.Message)
 			return
 		}
 


### PR DESCRIPTION
The cron task periodically checks the collateral balance through the orchestrator-api. However, I often find that the program outputs the log message ‘No sufficient collateral Balance, the current collateral balance is: 0.000.

I suspect that the status in the orchestrator-api response `{"data":{"balance":2000000000000},"message":"Successfully retrieved collateral balance","status":"success"}` is not always `status: success`,  which causes the default balance value to be 0. This might be the reason for the issue.