### PR TITLE
Using Umask on the Windows platform will generate compilation errors.

### DIFF
--- a/internal/computing/cp_service.go
+++ b/internal/computing/cp_service.go
@@ -174,6 +174,7 @@ func submitJob(jobData *models.JobData) error {
 		logs.GetLogger().Errorf("Failed to open file, error: %v", err)
 		return err
 	}
+
 	if _, err = f.Write(bytes); err != nil {
 		logs.GetLogger().Errorf("Failed jobData write to file, error: %v", err)
 		return err


### PR DESCRIPTION
On the Windows platform, there is no concept of Umask, so the submitJob function of cp_service.go will generate compilation errors on the Windows platform. We can avoid this problem by using the equivalent of setting file permissions.