### PR TITLE
confirmed ubuntu 24.04

### DIFF
--- a/ubi/setup.sh
+++ b/ubi/setup.sh
@@ -54,7 +54,7 @@ else
 								sudo apt-mark hold nvidia* libnvidia*
                                 ;;
 
-                            "22.04")
+                            "22.04"|"24.04")
                                 sudo -- sh -c 'apt-get update; apt-get remove needrestart -y; apt-get upgrade -y; apt-get autoremove -y; apt-get autoclean -y'
                                 sudo -- sh -c 'apt-get update; apt-get remove needrestart -y; apt-get upgrade -y; apt-get autoremove -y; apt-get autoclean -y'
                                 sudo apt install linux-headers-$(uname -r) -y


### PR DESCRIPTION
Support 24.04 on setup.sh.

I confirmed on Ubuntu 24.04

```shell
+ sudo bash -c 'cat <<EOF > /etc/docker/daemon.json
{
        "default-runtime": "nvidia",
        "runtimes": {
        "nvidia": {
        "path": "/usr/bin/nvidia-container-runtime",
        "runtimeArgs": []
                }
        }
}
EOF'
+ sudo systemctl restart docker
+ sudo docker run --rm --gpus all nvidia/cuda:11.0.3-base-ubuntu18.04 nvidia-smi
Tue Jul 30 17:35:17 2024
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 555.58.02              Driver Version: 555.58.02      CUDA Version: 12.5     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  Quadro P2000                   Off |   00000000:00:10.0 Off |                  N/A |
| 48%   36C    P8              4W /   75W |       2MiB /   5120MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
```