### PR TITLE
Allow contract address as a Owner Address

### DIFF
--- a/cmd/computing-provider/run.go
+++ b/cmd/computing-provider/run.go
@@ -711,10 +711,6 @@ var changeOwnerAddressCmd = &cli.Command{
 			return fmt.Errorf("the target newOwnerAddress is invalid wallet address")
 		}
 
-		if err := checkWalletAddress(newOwnerAddr, "owner"); err != nil {
-			return err
-		}
-
 		cpRepoPath, _ := os.LookupEnv("CP_PATH")
 
 		client, cpStub, err := getVerifyAccountClient(ownerAddress)


### PR DESCRIPTION
Delete the check that the owner address is the contract address