### PR TITLE
Add sync mining task status and show `rejected` tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ spec:
     spec:
       containers:
       - name: resource-exporter
-        image: filswan/resource-exporter:v11.3.1
+        image: filswan/resource-exporter:v11.3.2
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -355,6 +355,7 @@ make install
        WalletBlackList = ""                           # CP reject user addresses from this blacklist for space deployment
        Pricing = "true"                               # default True, indicating acceptance of smart pricing orders, which may include orders priced lower than self-determined pricing.
        AutoDeleteImage = false                        # Default false, automatically delete unused images
+       ClearLogDuration = 24                          # The interval for automatically clearing the log, the unit is hours
        PortRange= ["40000-40050","40070"]             # Externally exposed port number for deploying ECP image tasks
       
        [UBI]

--- a/build/version.go
+++ b/build/version.go
@@ -16,7 +16,7 @@ const UBITaskImageIntelCpu = "filswan/ubi-worker-cpu-intel:latest"
 const UBITaskImageIntelGpu = "filswan/ubi-worker-gpu-intel:latest"
 const UBITaskImageAmdCpu = "filswan/ubi-worker-cpu-amd:latest"
 const UBITaskImageAmdGpu = "filswan/ubi-worker-gpu-amd:latest"
-const UBIResourceExporterDockerImage = "filswan/resource-exporter:v11.3.1"
+const UBIResourceExporterDockerImage = "filswan/resource-exporter:v11.3.2"
 const TraefikServerDockerImage = "traefik:v2.10"
 
 func UserVersion() string {

--- a/build/version.go
+++ b/build/version.go
@@ -10,7 +10,7 @@ var CurrentCommit string
 
 var NetWorkTag string
 
-const BuildVersion = "1.0.1"
+const BuildVersion = "1.0.2"
 
 const UBITaskImageIntelCpu = "filswan/ubi-worker-cpu-intel:latest"
 const UBITaskImageIntelGpu = "filswan/ubi-worker-gpu-intel:latest"

--- a/cmd/computing-provider/ubi.go
+++ b/cmd/computing-provider/ubi.go
@@ -239,6 +239,8 @@ var daemonCmd = &cli.Command{
 func getStatusColor(taskStatus int) []tablewriter.Colors {
 	var rowColor []tablewriter.Colors
 	switch taskStatus {
+	case models.TASK_REJECTED_STATUS:
+		rowColor = []tablewriter.Colors{{tablewriter.Bold, tablewriter.FgRedColor}}
 	case models.TASK_RECEIVED_STATUS:
 		rowColor = []tablewriter.Colors{{tablewriter.Bold, tablewriter.FgYellowColor}}
 	case models.TASK_RUNNING_STATUS:

--- a/conf/config.go
+++ b/conf/config.go
@@ -216,6 +216,9 @@ func getConfigByHeight() {
 			config.UBI.EdgeUrl = ncCopy.Config.EdgeUrl
 			config.CONTRACT.ZkCollateralUbiZero = ncCopy.Config.ZkCollateralUbiZeroContract
 			config.CONTRACT.JobCollateralUbiZero = ncCopy.Config.OrchestratorCollateralUbiZeroContract
+			if config.API.ClearLogDuration == 0 {
+				config.API.ClearLogDuration = 24
+			}
 		}
 	}
 }

--- a/conf/config.go
+++ b/conf/config.go
@@ -46,15 +46,16 @@ type ComputeNode struct {
 }
 
 type API struct {
-	Port            int
-	MultiAddress    string
-	Domain          string
-	NodeName        string
-	WalletWhiteList string
-	WalletBlackList string
-	Pricing         Pricing  `toml:"pricing"`
-	AutoDeleteImage bool     `toml:"AutoDeleteImage"`
-	PortRange       []string `toml:"PortRange"`
+	Port             int
+	MultiAddress     string
+	Domain           string
+	NodeName         string
+	WalletWhiteList  string
+	WalletBlackList  string
+	Pricing          Pricing  `toml:"pricing"`
+	AutoDeleteImage  bool     `toml:"AutoDeleteImage"`
+	ClearLogDuration int      `toml:"ClearLogDuration"`
+	PortRange        []string `toml:"PortRange"`
 }
 type UBI struct {
 	UbiEnginePk     string
@@ -71,7 +72,6 @@ type LOG struct {
 }
 
 type HUB struct {
-	AccessToken      string
 	BalanceThreshold float64
 	OrchestratorPk   string
 	VerifySign       bool

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -7,6 +7,7 @@ WalletWhiteList = ""                                                     # CP ac
 WalletBlackList = ""                                                     # CP reject user addresses from this blacklist for space deployment
 Pricing = "true"                                                         # Default True, indicating acceptance of smart pricing orders, which may include orders priced lower than self-determined pricing.
 AutoDeleteImage = false                                                  # Default false, automatically delete unused images
+ClearLogDuration = 24                                                    # The interval for automatically clearing the log, the unit is hours
 PortRange = ["40000-40050","40070"]                                      # Externally exposed port number for deploying multi-port image tasks
 
 

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -7,7 +7,7 @@ WalletWhiteList = ""                                                     # CP ac
 WalletBlackList = ""                                                     # CP reject user addresses from this blacklist for space deployment
 Pricing = "true"                                                         # Default True, indicating acceptance of smart pricing orders, which may include orders priced lower than self-determined pricing.
 AutoDeleteImage = false                                                  # Default false, automatically delete unused images
-ClearLogDuration = 24                                                    # The interval for automatically clearing the log, the unit is hours
+ClearLogDuration = 24                                                    # Delete logs at intervals after the job is finished, the unit is hours
 PortRange = ["40000-40050","40070"]                                      # Externally exposed port number for deploying multi-port image tasks
 
 

--- a/constants/utils.go
+++ b/constants/utils.go
@@ -1,16 +1,5 @@
 package constants
 
-const StatusActive = "Active"
-const StatusOffline = "Offline"
-
-// bidding status
-const BiddingCreated string = "created"
-const BiddingAccepting string = "accepting_bids"
-const BiddingProcessing string = "processing"
-const BiddingSubmitted string = "submitted"
-const BiddingCompleted string = "completed"
-const BiddingCancelled string = "cancelled"
-
 const K8S_NAMESPACE_NAME_PREFIX = "ns-"
 const K8S_CONTAINER_NAME_PREFIX = "pod-"
 const K8S_PRIVATE_CONTAINER_PREFIX = "vm-"
@@ -28,4 +17,11 @@ const (
 	BidMode_Auto
 	BidMode_Private
 	BidMode_None
+)
+
+const (
+	BUILD_IMAGE_PATH_PREFIX = "build"
+	LOG_PATH_PREFIX         = "logs"
+	BUILD_LOG_NAME          = "build.log"
+	Container_LOG_NAME      = "container.log"
 )

--- a/internal/computing/buildspace.go
+++ b/internal/computing/buildspace.go
@@ -122,7 +122,7 @@ func BuildImagesByDockerfile(jobUuid, spaceName, imagePath string) (string, stri
 	log.Printf("Image path: %s", imagePath)
 
 	dockerService := NewDockerService()
-	if err := dockerService.BuildImage(imagePath, imageName); err != nil {
+	if err := dockerService.BuildImage(jobUuid, imagePath, imageName); err != nil {
 		logs.GetLogger().Errorf("Error building Docker image: %v", err)
 		return "", ""
 	}

--- a/internal/computing/cron_task.go
+++ b/internal/computing/cron_task.go
@@ -659,7 +659,8 @@ func checkFcpJobInfoInChain(job *models.JobEntity) {
 type TaskGroup struct {
 	Items []*models.TaskEntity
 	Ids   []int64
-	Type  int // 1: contract  2: sequncer
+	Uuids []string
+	Type  int // 1: contract  2: sequncer 3: mining
 }
 
 func handleTasksToGroup(list []*models.TaskEntity) []TaskGroup {
@@ -707,7 +708,7 @@ func handleTasksToGroupForMining(list []*models.TaskEntity) []TaskGroup {
 			group = TaskGroup{}
 		}
 		group.Items = append(group.Items, list[i])
-		group.Ids = append(group.Ids, list[i].Id)
+		group.Uuids = append(group.Uuids, list[i].Uuid)
 		group.Type = 3
 	}
 	if len(group.Items) > 0 {

--- a/internal/computing/cron_task.go
+++ b/internal/computing/cron_task.go
@@ -571,7 +571,7 @@ func addNodeLabel() {
 
 func (task *CronTask) CheckCpBalance() {
 	c := cron.New(cron.WithSeconds())
-	c.AddFunc("0 0/30 * * *", func() {
+	c.AddFunc("0 0/30 * * * ?", func() {
 		defer func() {
 			if err := recover(); err != nil {
 				logs.GetLogger().Errorf("check cp balance catch panic error: %+v", err)
@@ -584,7 +584,7 @@ func (task *CronTask) CheckCpBalance() {
 
 func (task *CronTask) UpdateContainerLog() {
 	c := cron.New(cron.WithSeconds())
-	c.AddFunc("* 0/10 * * *", func() {
+	c.AddFunc("* 0/10 * * * ?", func() {
 		defer func() {
 			if err := recover(); err != nil {
 				logs.GetLogger().Errorf("update container log catch panic error: %+v", err)

--- a/internal/computing/cron_task.go
+++ b/internal/computing/cron_task.go
@@ -606,7 +606,7 @@ func (task *CronTask) UpdateContainerLog() {
 
 func (task *CronTask) DeleteSpaceLog() {
 	c := cron.New(cron.WithSeconds())
-	c.AddFunc("* 0/30 * * *", func() {
+	c.AddFunc("* 0/5 * * *", func() {
 		defer func() {
 			if err := recover(); err != nil {
 				logs.GetLogger().Errorf("update container log catch panic error: %+v", err)

--- a/internal/computing/cron_task.go
+++ b/internal/computing/cron_task.go
@@ -606,7 +606,7 @@ func (task *CronTask) UpdateContainerLog() {
 
 func (task *CronTask) DeleteSpaceLog() {
 	c := cron.New(cron.WithSeconds())
-	c.AddFunc("* 0/5 * * *", func() {
+	c.AddFunc("0 0/5 * * * ?", func() {
 		defer func() {
 			if err := recover(); err != nil {
 				logs.GetLogger().Errorf("update container log catch panic error: %+v", err)
@@ -618,10 +618,12 @@ func (task *CronTask) DeleteSpaceLog() {
 			logs.GetLogger().Errorf("failed to get job data, error: %+v", err)
 			return
 		}
+		cpRepoPath, _ := os.LookupEnv("CP_PATH")
 
 		for _, job := range jobList {
+			logs.GetLogger().Infof("cpRepoPath: %s,job_uuid: %s, ExpireTime: %d, result: %t ", cpRepoPath, job.JobUuid, job.ExpireTime, job.ExpireTime+int64(conf.GetConfig().API.ClearLogDuration)*3600 < time.Now().Unix())
 			if job.ExpireTime+int64(conf.GetConfig().API.ClearLogDuration)*3600 < time.Now().Unix() {
-				cpRepoPath, _ := os.LookupEnv("CP_PATH")
+
 				err := os.RemoveAll(filepath.Join(cpRepoPath, constants.LOG_PATH_PREFIX, job.JobUuid))
 				if err != nil {
 					logs.GetLogger().Errorf("failed to delete logs, job_uuid: %s, error: %v", job.JobUuid, err)

--- a/internal/computing/cron_task.go
+++ b/internal/computing/cron_task.go
@@ -622,8 +622,7 @@ func (task *CronTask) DeleteSpaceLog() {
 		for _, job := range jobList {
 			if job.ExpireTime+int64(conf.GetConfig().API.ClearLogDuration)*3600 < time.Now().Unix() {
 				cpRepoPath, _ := os.LookupEnv("CP_PATH")
-				logDir := filepath.Join(cpRepoPath, constants.LOG_PATH_PREFIX, job.JobUuid)
-				err := os.Remove(logDir)
+				err := os.RemoveAll(filepath.Join(cpRepoPath, constants.LOG_PATH_PREFIX, job.JobUuid))
 				if err != nil {
 					logs.GetLogger().Errorf("failed to delete logs, job_uuid: %s, error: %v", job.JobUuid, err)
 					continue

--- a/internal/computing/cron_task.go
+++ b/internal/computing/cron_task.go
@@ -695,3 +695,23 @@ func handleTasksToGroup(list []*models.TaskEntity) []TaskGroup {
 	}
 	return groups
 }
+
+func handleTasksToGroupForMining(list []*models.TaskEntity) []TaskGroup {
+	var groups []TaskGroup
+	var group TaskGroup
+
+	const batchSize = 20
+	for i := 0; i < len(list); i++ {
+		if len(group.Items) > batchSize {
+			groups = append(groups, group)
+			group = TaskGroup{}
+		}
+		group.Items = append(group.Items, list[i])
+		group.Ids = append(group.Ids, list[i].Id)
+		group.Type = 3
+	}
+	if len(group.Items) > 0 {
+		groups = append(groups, group)
+	}
+	return groups
+}

--- a/internal/computing/cron_task.go
+++ b/internal/computing/cron_task.go
@@ -701,7 +701,7 @@ func handleTasksToGroupForMining(list []*models.TaskEntity) []TaskGroup {
 	var groups []TaskGroup
 	var group TaskGroup
 
-	const batchSize = 20
+	const batchSize = 10
 	for i := 0; i < len(list); i++ {
 		if len(group.Items) > batchSize {
 			groups = append(groups, group)

--- a/internal/computing/cron_task.go
+++ b/internal/computing/cron_task.go
@@ -606,7 +606,7 @@ func (task *CronTask) UpdateContainerLog() {
 
 func (task *CronTask) DeleteSpaceLog() {
 	c := cron.New(cron.WithSeconds())
-	c.AddFunc("0 0/5 * * * ?", func() {
+	c.AddFunc("0 0/30 * * * ?", func() {
 		defer func() {
 			if err := recover(); err != nil {
 				logs.GetLogger().Errorf("update container log catch panic error: %+v", err)
@@ -621,9 +621,10 @@ func (task *CronTask) DeleteSpaceLog() {
 		cpRepoPath, _ := os.LookupEnv("CP_PATH")
 
 		for _, job := range jobList {
-			logs.GetLogger().Infof("cpRepoPath: %s,job_uuid: %s, ExpireTime: %d, result: %t ", cpRepoPath, job.JobUuid, job.ExpireTime, job.ExpireTime+int64(conf.GetConfig().API.ClearLogDuration)*3600 < time.Now().Unix())
+			if job.CreateTime+int64(24*7*3600) < time.Now().Unix() {
+				continue
+			}
 			if job.ExpireTime+int64(conf.GetConfig().API.ClearLogDuration)*3600 < time.Now().Unix() {
-
 				err := os.RemoveAll(filepath.Join(cpRepoPath, constants.LOG_PATH_PREFIX, job.JobUuid))
 				if err != nil {
 					logs.GetLogger().Errorf("failed to delete logs, job_uuid: %s, error: %v", job.JobUuid, err)

--- a/internal/computing/deploy.go
+++ b/internal/computing/deploy.go
@@ -419,7 +419,10 @@ func (d *Deploy) ModelInferenceToK8s() error {
 
 	imageName := "lagrange/" + modelInfo.Framework + ":v1.0"
 
-	logFile := filepath.Join(d.SpacePath, BuildFileName)
+	logDir := filepath.Join(cpPath, constants.LOG_PATH_PREFIX, d.originalJobUuid)
+	os.MkdirAll(logDir, os.ModePerm)
+
+	logFile := filepath.Join(logDir, constants.BUILD_LOG_NAME)
 	if _, err = os.Create(logFile); err != nil {
 		return err
 	}

--- a/internal/computing/docker_service.go
+++ b/internal/computing/docker_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/filswan/go-mcs-sdk/mcs/api/common/logs"
 	"github.com/swanchain/go-computing-provider/build"
+	"github.com/swanchain/go-computing-provider/constants"
 	"io"
 	"os"
 	"os/exec"
@@ -31,8 +32,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 )
-
-const BuildFileName = "build.log"
 
 type DockerService struct {
 	c *client.Client
@@ -75,7 +74,7 @@ func ExtractExposedPort(dockerfilePath string) (string, error) {
 	return exposedPort, nil
 }
 
-func (ds *DockerService) BuildImage(buildPath, imageName string) error {
+func (ds *DockerService) BuildImage(jobUuid, buildPath, imageName string) error {
 	// Create a buffer
 	buf := new(bytes.Buffer)
 	tw := tar.NewWriter(buf)
@@ -120,7 +119,11 @@ func (ds *DockerService) BuildImage(buildPath, imageName string) error {
 	}
 	defer buildResponse.Body.Close()
 
-	logFile, err := os.Create(filepath.Join(buildPath, BuildFileName))
+	cpRepoPath, _ := os.LookupEnv("CP_PATH")
+	logDir := filepath.Join(cpRepoPath, constants.LOG_PATH_PREFIX, jobUuid)
+	os.MkdirAll(logDir, os.ModePerm)
+
+	logFile, err := os.Create(filepath.Join(logDir, constants.BUILD_LOG_NAME))
 	if err != nil {
 		return err
 	}

--- a/internal/computing/ecp_image_service.go
+++ b/internal/computing/ecp_image_service.go
@@ -479,7 +479,7 @@ func (*ImageJobService) DeployMining(c *gin.Context, deployJob models.DeployJobP
 	}
 	go func() {
 		if deployJob.BuildImagePath != "" && deployJob.BuildImageName != "" {
-			if err := NewDockerService().BuildImage(deployJob.BuildImagePath, deployJob.BuildImageName); err != nil {
+			if err := NewDockerService().BuildImage(deployJob.Uuid, deployJob.BuildImagePath, deployJob.BuildImageName); err != nil {
 				logs.GetLogger().Errorf("failed to building %s image, job_uuid: %s, error: %v", deployJob.Image, deployJob.Uuid, err)
 				NewEcpJobService().UpdateEcpJobEntityMessage(deployJob.Uuid, fmt.Sprintf("failed to build image: %s", deployJob.Image))
 			}
@@ -564,7 +564,7 @@ func (*ImageJobService) DeployInference(c *gin.Context, deployJob models.DeployJ
 
 	go func() {
 		if deployJob.BuildImagePath != "" && deployJob.BuildImageName != "" {
-			if err := NewDockerService().BuildImage(deployJob.BuildImagePath, deployJob.BuildImageName); err != nil {
+			if err := NewDockerService().BuildImage(deployJob.Uuid, deployJob.BuildImagePath, deployJob.BuildImageName); err != nil {
 				logs.GetLogger().Errorf("failed to building %s image, job_uuid: %s, error: %v", deployJob.Image, deployJob.Uuid, err)
 				NewEcpJobService().UpdateEcpJobEntityMessage(deployJob.Uuid, fmt.Sprintf("failed to build image: %s", deployJob.Image))
 			}

--- a/internal/computing/entity_service.go
+++ b/internal/computing/entity_service.go
@@ -82,7 +82,7 @@ func (taskServ TaskService) GetTaskListNoRewardForFilC2() (list []*models.TaskEn
 }
 
 func (taskServ TaskService) GetTaskListNoRewardForMining() (list []*models.TaskEntity, err error) {
-	err = taskServ.Model(&models.TaskEntity{}).Where("uuid !='' and (status !=? or status !=? or status !=?) ", models.TASK_TIMEOUT_STATUS,
+	err = taskServ.Debug().Model(&models.TaskEntity{}).Where("uuid !='' and (status !=? or status !=? or status !=?) ", models.TASK_TIMEOUT_STATUS,
 		models.TASK_VERIFYFAILED_STATUS, models.TASK_VERIFIED_STATUS).Find(&list).Error
 	if err != nil {
 		return nil, err

--- a/internal/computing/entity_service.go
+++ b/internal/computing/entity_service.go
@@ -64,7 +64,7 @@ func (taskServ TaskService) UpdateTaskEntityByTaskId(task *models.TaskEntity) (e
 }
 
 func (taskServ TaskService) UpdateTaskEntityByTaskUuId(task *models.TaskEntity) (err error) {
-	return taskServ.Model(&models.TaskEntity{}).Where("uuid=?", task.Uuid).Updates(task).Error
+	return taskServ.Debug().Model(&models.TaskEntity{}).Where("uuid=?", task.Uuid).Updates(task).Error
 }
 
 func (taskServ TaskService) GetTaskEntity(taskId int64) (*models.TaskEntity, error) {
@@ -82,7 +82,7 @@ func (taskServ TaskService) GetTaskListNoRewardForFilC2() (list []*models.TaskEn
 }
 
 func (taskServ TaskService) GetTaskListNoRewardForMining() (list []*models.TaskEntity, err error) {
-	err = taskServ.Model(&models.TaskEntity{}).Where("uuid !='' and (status !=? or status !=? or status !=?) ", models.TASK_TIMEOUT_STATUS,
+	err = taskServ.Debug().Model(&models.TaskEntity{}).Where("uuid !='' and (status !=? or status !=? or status !=?) ", models.TASK_TIMEOUT_STATUS,
 		models.TASK_VERIFYFAILED_STATUS, models.TASK_VERIFIED_STATUS).Find(&list).Error
 	if err != nil {
 		return nil, err

--- a/internal/computing/entity_service.go
+++ b/internal/computing/entity_service.go
@@ -63,6 +63,10 @@ func (taskServ TaskService) UpdateTaskEntityByTaskId(task *models.TaskEntity) (e
 	return taskServ.Model(&models.TaskEntity{}).Where("id=?", task.Id).Updates(task).Error
 }
 
+func (taskServ TaskService) UpdateTaskEntityByTaskUuId(task *models.TaskEntity) (err error) {
+	return taskServ.Model(&models.TaskEntity{}).Where("uuid=?", task.Uuid).Updates(task).Error
+}
+
 func (taskServ TaskService) GetTaskEntity(taskId int64) (*models.TaskEntity, error) {
 	var taskEntity models.TaskEntity
 	err := taskServ.First(&taskEntity, taskId).Error
@@ -78,7 +82,8 @@ func (taskServ TaskService) GetTaskListNoRewardForFilC2() (list []*models.TaskEn
 }
 
 func (taskServ TaskService) GetTaskListNoRewardForMining() (list []*models.TaskEntity, err error) {
-	err = taskServ.Model(&models.TaskEntity{}).Where("uuid !=''", models.TaskSequencer).Find(&list).Error
+	err = taskServ.Model(&models.TaskEntity{}).Where("uuid !='' and (status !=? or status !=? or status !=?) ", models.TASK_TIMEOUT_STATUS,
+		models.TASK_VERIFYFAILED_STATUS, models.TASK_VERIFIED_STATUS).Find(&list).Error
 	if err != nil {
 		return nil, err
 	}

--- a/internal/computing/entity_service.go
+++ b/internal/computing/entity_service.go
@@ -64,7 +64,7 @@ func (taskServ TaskService) UpdateTaskEntityByTaskId(task *models.TaskEntity) (e
 }
 
 func (taskServ TaskService) UpdateTaskEntityByTaskUuId(task *models.TaskEntity) (err error) {
-	return taskServ.Model(&models.TaskEntity{}).Where("uuid=?", task.Uuid).Updates(task).Error
+	return taskServ.Debug().Model(&models.TaskEntity{}).Where("uuid=?", task.Uuid).Updates(task).Error
 }
 
 func (taskServ TaskService) GetTaskEntity(taskId int64) (*models.TaskEntity, error) {

--- a/internal/computing/entity_service.go
+++ b/internal/computing/entity_service.go
@@ -64,7 +64,7 @@ func (taskServ TaskService) UpdateTaskEntityByTaskId(task *models.TaskEntity) (e
 }
 
 func (taskServ TaskService) UpdateTaskEntityByTaskUuId(task *models.TaskEntity) (err error) {
-	return taskServ.Debug().Model(&models.TaskEntity{}).Where("uuid=?", task.Uuid).Updates(task).Error
+	return taskServ.Model(&models.TaskEntity{}).Where("uuid=?", task.Uuid).Updates(task).Error
 }
 
 func (taskServ TaskService) GetTaskEntity(taskId int64) (*models.TaskEntity, error) {
@@ -82,7 +82,7 @@ func (taskServ TaskService) GetTaskListNoRewardForFilC2() (list []*models.TaskEn
 }
 
 func (taskServ TaskService) GetTaskListNoRewardForMining() (list []*models.TaskEntity, err error) {
-	err = taskServ.Debug().Model(&models.TaskEntity{}).Where("uuid !='' and (status !=? or status !=? or status !=?) ", models.TASK_TIMEOUT_STATUS,
+	err = taskServ.Model(&models.TaskEntity{}).Where("uuid !='' and (status !=? or status !=? or status !=?) ", models.TASK_TIMEOUT_STATUS,
 		models.TASK_VERIFYFAILED_STATUS, models.TASK_VERIFIED_STATUS).Find(&list).Error
 	if err != nil {
 		return nil, err

--- a/internal/computing/entity_service.go
+++ b/internal/computing/entity_service.go
@@ -69,8 +69,16 @@ func (taskServ TaskService) GetTaskEntity(taskId int64) (*models.TaskEntity, err
 	return &taskEntity, err
 }
 
-func (taskServ TaskService) GetTaskListNoReward() (list []*models.TaskEntity, err error) {
-	err = taskServ.Model(&models.TaskEntity{}).Where("sequencer=? and sequence_task_addr ==''", models.TaskSequencer).Find(&list).Error
+func (taskServ TaskService) GetTaskListNoRewardForFilC2() (list []*models.TaskEntity, err error) {
+	err = taskServ.Model(&models.TaskEntity{}).Where("sequencer=? and sequence_task_addr =='' and uuid=''", models.TaskSequencer).Find(&list).Error
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+func (taskServ TaskService) GetTaskListNoRewardForMining() (list []*models.TaskEntity, err error) {
+	err = taskServ.Model(&models.TaskEntity{}).Where("uuid !=''", models.TaskSequencer).Find(&list).Error
 	if err != nil {
 		return nil, err
 	}
@@ -280,12 +288,12 @@ func (cpServ CpBalanceService) SaveCpBalance(cpBalance models.CpBalanceEntity) (
 
 func (cpServ CpBalanceService) GetCpBalance(cpAccount string) (*models.CpBalanceEntity, error) {
 	var cpBalance models.CpBalanceEntity
-	err := cpServ.Model(&models.CpBalanceEntity{}).Where("cp_account=?", cpAccount).Limit(1).Find(&cpBalance).Error
+	err := cpServ.Model(&models.CpBalanceEntity{}).Where("cp_account=?", cpAccount).Order("id desc").Limit(1).Find(&cpBalance).Error
 	return &cpBalance, err
 }
 
 func (cpServ CpBalanceService) UpdateCpBalance(cpBalance models.CpBalanceEntity) error {
-	err := cpServ.Model(&models.CpBalanceEntity{}).Where("cp_account=?", cpBalance.CpAccount).Updates(map[string]interface{}{
+	err := cpServ.Model(&models.CpBalanceEntity{}).Where("cp_account=? and id=?", cpBalance.CpAccount, cpBalance.Id).Updates(map[string]interface{}{
 		"worker_balance":    cpBalance.WorkerBalance,
 		"sequencer_balance": cpBalance.SequencerBalance,
 	}).Error

--- a/internal/computing/sequence_service.go
+++ b/internal/computing/sequence_service.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/filswan/go-mcs-sdk/mcs/api/common/logs"
 	"github.com/swanchain/go-computing-provider/conf"
 	"github.com/swanchain/go-computing-provider/internal/contract"
 	"github.com/swanchain/go-computing-provider/internal/contract/account"
@@ -17,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type Sequencer struct {
@@ -163,16 +163,9 @@ func (s *Sequencer) QueryTask(taskType int, taskIds []int64, uuids []string) (Ta
 			return TaskListResp{}, fmt.Errorf("failed to get token, error: %v", err)
 		}
 	}
-
-	logs.GetLogger().Infof("token: %s", tokenCache)
 	var reqUrl string
 	if taskType == 3 {
-		reqData, err := json.Marshal(uuids)
-		if err != nil {
-			return TaskListResp{}, err
-		}
-		reqUrl = s.url + task + fmt.Sprintf("?type=%d&uuids=%s", taskType, string(reqData))
-		logs.GetLogger().Infof("reqUrl: %s", reqUrl)
+		reqUrl = s.url + task + fmt.Sprintf("?type=%d&uuids=%s", taskType, strings.Join(uuids, ","))
 	} else {
 		reqData, err := json.Marshal(taskIds)
 		if err != nil {
@@ -205,7 +198,6 @@ func (s *Sequencer) QueryTask(taskType int, taskIds []int64, uuids []string) (Ta
 	if err != nil {
 		return TaskListResp{}, fmt.Errorf("error reading response: %v", err)
 	}
-	logs.GetLogger().Infof("body: %s", string(body))
 
 	var taskListResp TaskListResp
 	if resp.StatusCode != http.StatusOK {

--- a/internal/computing/sequence_service.go
+++ b/internal/computing/sequence_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/filswan/go-mcs-sdk/mcs/api/common/logs"
 	"github.com/swanchain/go-computing-provider/conf"
 	"github.com/swanchain/go-computing-provider/internal/contract"
 	"github.com/swanchain/go-computing-provider/internal/contract/account"
@@ -165,11 +166,14 @@ func (s *Sequencer) QueryTask(taskType int, taskIds []int64, uuids []string) (Ta
 
 	var reqUrl string
 	if taskType == 3 {
+		if err := s.GetToken(); err != nil {
+			return TaskListResp{}, fmt.Errorf("failed to get token, error: %v", err)
+		}
+
 		reqData, err := json.Marshal(uuids)
 		if err != nil {
 			return TaskListResp{}, err
 		}
-
 		reqUrl = s.url + task + fmt.Sprintf("?type=%d&uuids=%s", taskType, string(reqData))
 	} else {
 		reqData, err := json.Marshal(taskIds)
@@ -203,6 +207,8 @@ func (s *Sequencer) QueryTask(taskType int, taskIds []int64, uuids []string) (Ta
 	if err != nil {
 		return TaskListResp{}, fmt.Errorf("error reading response: %v", err)
 	}
+	logs.GetLogger().Infof("token: %s", tokenCache)
+	logs.GetLogger().Infof("body: %s", string(body))
 
 	var taskListResp TaskListResp
 	if resp.StatusCode != http.StatusOK {

--- a/internal/computing/sequence_service.go
+++ b/internal/computing/sequence_service.go
@@ -164,17 +164,15 @@ func (s *Sequencer) QueryTask(taskType int, taskIds []int64, uuids []string) (Ta
 		}
 	}
 
+	logs.GetLogger().Infof("token: %s", tokenCache)
 	var reqUrl string
 	if taskType == 3 {
-		if err := s.GetToken(); err != nil {
-			return TaskListResp{}, fmt.Errorf("failed to get token, error: %v", err)
-		}
-
 		reqData, err := json.Marshal(uuids)
 		if err != nil {
 			return TaskListResp{}, err
 		}
 		reqUrl = s.url + task + fmt.Sprintf("?type=%d&uuids=%s", taskType, string(reqData))
+		logs.GetLogger().Infof("reqUrl: %s", reqUrl)
 	} else {
 		reqData, err := json.Marshal(taskIds)
 		if err != nil {
@@ -207,7 +205,6 @@ func (s *Sequencer) QueryTask(taskType int, taskIds []int64, uuids []string) (Ta
 	if err != nil {
 		return TaskListResp{}, fmt.Errorf("error reading response: %v", err)
 	}
-	logs.GetLogger().Infof("token: %s", tokenCache)
 	logs.GetLogger().Infof("body: %s", string(body))
 
 	var taskListResp TaskListResp

--- a/internal/computing/sequence_service.go
+++ b/internal/computing/sequence_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/filswan/go-mcs-sdk/mcs/api/common/logs"
 	"github.com/swanchain/go-computing-provider/conf"
 	"github.com/swanchain/go-computing-provider/internal/contract"
 	"github.com/swanchain/go-computing-provider/internal/contract/account"
@@ -168,12 +169,19 @@ func (s *Sequencer) QueryTask(taskType int, taskIds ...int64) (TaskListResp, err
 		return TaskListResp{}, err
 	}
 
-	var reqUrl = s.url + task + fmt.Sprintf("?type=%d&ids=%s", taskType, string(reqData))
+	var reqUrl string
+	if taskType == 3 {
+		reqUrl = s.url + task + fmt.Sprintf("?type=%d&uuids=%s", taskType, string(reqData))
+	} else {
+		reqUrl = s.url + task + fmt.Sprintf("?type=%d&ids=%s", taskType, string(reqData))
+	}
+
 	req, err := http.NewRequest("GET", reqUrl, nil)
 	if err != nil {
 		return TaskListResp{}, fmt.Errorf("error creating request: %v", err)
 	}
 
+	logs.GetLogger().Infof("tokenCache: %s", tokenCache)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Authorization", tokenCache)
 	client := &http.Client{}

--- a/internal/computing/ubi_service.go
+++ b/internal/computing/ubi_service.go
@@ -301,12 +301,14 @@ func DoUbiTaskForK8s(c *gin.Context) {
 			return
 		}
 
+		var nodeSelector = make(map[string]string)
 		if gpuFlag == "0" {
 			delete(envVars, "RUST_GPU_TOOLS_CUSTOM_GPU")
 			envVars["BELLMAN_NO_GPU"] = "1"
 		} else {
 			if len(gpuIndex) > 0 {
 				envVars["CUDA_VISIBLE_DEVICES"] = gpuIndex[0]
+				nodeSelector = generateLabel(strings.ReplaceAll(c2GpuName, " ", "-"))
 			}
 		}
 
@@ -346,7 +348,7 @@ func DoUbiTaskForK8s(c *gin.Context) {
 				Template: v1.PodTemplateSpec{
 					Spec: v1.PodSpec{
 						NodeName:     nodeName,
-						NodeSelector: generateLabel(strings.ReplaceAll(c2GpuName, " ", "-")),
+						NodeSelector: nodeSelector,
 						Containers: []v1.Container{
 							{
 								Name:  JobName + generateString(5),

--- a/internal/computing/ubi_service.go
+++ b/internal/computing/ubi_service.go
@@ -1372,7 +1372,7 @@ func syncUbiMiningTaskStatus() {
 	}
 
 	taskGroups := handleTasksToGroupForMining(taskList)
-	var taskIdAndStatus = make(map[string]string)
+	var taskIdAndStatus = make(map[int64]string)
 	for _, group := range taskGroups {
 		taskList, err := NewSequencer().QueryTask(group.Type, nil, group.Uuids)
 		if err != nil {
@@ -1416,7 +1416,7 @@ func syncUbiMiningTaskStatus() {
 				if item.Status == status {
 					continue
 				}
-				taskIdAndStatus[item.Uuid] = models.TaskStatusStr(status)
+				taskIdAndStatus[item.Id] = models.TaskStatusStr(status)
 				item.Status = status
 				NewTaskService().UpdateTaskEntityByTaskUuId(item)
 			}

--- a/internal/computing/ubi_service.go
+++ b/internal/computing/ubi_service.go
@@ -1278,9 +1278,9 @@ func CronTaskForEcp() {
 }
 
 func syncTaskStatusForSequencerService() error {
-	taskList, err := NewTaskService().GetTaskListNoReward()
+	taskList, err := NewTaskService().GetTaskListNoRewardForFilC2()
 	if err != nil {
-		return fmt.Errorf("failed to get task list, error: %+v", err)
+		return fmt.Errorf("failed to get ubi fil-c2 task list, error: %+v", err)
 	}
 
 	taskGroups := handleTasksToGroup(taskList)
@@ -1356,6 +1356,26 @@ func syncTaskStatusForSequencerService() error {
 		logs.GetLogger().Infof("successfully updated the task status: %v", taskIdAndStatus)
 	}
 	return nil
+}
+
+func syncUbiMiningTaskStatus() {
+	//taskList, err := NewTaskService().GetTaskListNoRewardForMining()
+	//if err != nil {
+	//	logs.GetLogger().Errorf("failed to get ubi mining task list, error: %+v", err)
+	//	return
+	//}
+	//
+	//taskGroups := handleTasksToGroup(taskList)
+	//var taskIdAndStatus = make(map[int64]string)
+	//for _, group := range taskGroups {
+	//	taskList, err := NewSequencer().QueryTask(group.Type, group.Ids...)
+	//	if err != nil {
+	//		logs.GetLogger().Errorf("failed to query task, task ids: %v, error: %v", group.Ids, err)
+	//		continue
+	//	}
+	//
+	//}
+
 }
 
 func SyncCpAccountInfo() (*models.Account, error) {
@@ -1641,9 +1661,10 @@ func GetCpBalance() {
 		SequencerBalance: roundToSixDecimal(sequencerBalance),
 	}
 	cpBalanceEntity, err := NewCpBalanceService().GetCpBalance(cpAccountAddress)
-	if err != nil || cpBalanceEntity == nil || cpBalanceEntity.WorkerBalance == 0 {
+	if err != nil || cpBalanceEntity == nil {
 		err = NewCpBalanceService().SaveCpBalance(cpBalance)
 	} else {
+		cpBalance.Id = cpBalanceEntity.Id
 		err = NewCpBalanceService().UpdateCpBalance(cpBalance)
 	}
 

--- a/internal/computing/ubi_service.go
+++ b/internal/computing/ubi_service.go
@@ -1374,7 +1374,6 @@ func syncUbiMiningTaskStatus() {
 	taskGroups := handleTasksToGroupForMining(taskList)
 	var taskIdAndStatus = make(map[string]string)
 	for _, group := range taskGroups {
-		logs.GetLogger().Infof("group: %+v", group)
 		taskList, err := NewSequencer().QueryTask(group.Type, nil, group.Uuids)
 		if err != nil {
 			logs.GetLogger().Errorf("failed to query task, task ids: %v, error: %v", group.Uuids, err)

--- a/internal/computing/ubi_service.go
+++ b/internal/computing/ubi_service.go
@@ -1371,7 +1371,7 @@ func syncUbiMiningTaskStatus() {
 		return
 	}
 
-	taskGroups := handleTasksToGroup(taskList)
+	taskGroups := handleTasksToGroupForMining(taskList)
 	var taskIdAndStatus = make(map[int64]string)
 	for _, group := range taskGroups {
 		taskList, err := NewSequencer().QueryTask(group.Type, group.Ids...)

--- a/internal/computing/ubi_service.go
+++ b/internal/computing/ubi_service.go
@@ -1719,7 +1719,7 @@ func GetCpBalance() {
 		SequencerBalance: roundToSixDecimal(sequencerBalance),
 	}
 	cpBalanceEntity, err := NewCpBalanceService().GetCpBalance(cpAccountAddress)
-	fmt.Printf("cpBalanceEntity: %v, err: %v", cpBalanceEntity, err)
+	fmt.Printf("cpBalanceEntity: %v, err: %v, %t", cpBalanceEntity, err, cpBalanceEntity == nil)
 	if err != nil || cpBalanceEntity == nil {
 		err = NewCpBalanceService().SaveCpBalance(cpBalance)
 	} else {

--- a/internal/computing/ubi_service.go
+++ b/internal/computing/ubi_service.go
@@ -1719,8 +1719,7 @@ func GetCpBalance() {
 		SequencerBalance: roundToSixDecimal(sequencerBalance),
 	}
 	cpBalanceEntity, err := NewCpBalanceService().GetCpBalance(cpAccountAddress)
-	fmt.Printf("cpBalanceEntity: %v, err: %v, %t", cpBalanceEntity, err, cpBalanceEntity == nil)
-	if err != nil || cpBalanceEntity == nil {
+	if err != nil || cpBalanceEntity.CpAccount == "" {
 		err = NewCpBalanceService().SaveCpBalance(cpBalance)
 	} else {
 		cpBalance.Id = cpBalanceEntity.Id

--- a/internal/computing/ubi_service.go
+++ b/internal/computing/ubi_service.go
@@ -1374,9 +1374,10 @@ func syncUbiMiningTaskStatus() {
 	taskGroups := handleTasksToGroupForMining(taskList)
 	var taskIdAndStatus = make(map[string]string)
 	for _, group := range taskGroups {
+		logs.GetLogger().Infof("group: %+v", group)
 		taskList, err := NewSequencer().QueryTask(group.Type, nil, group.Uuids)
 		if err != nil {
-			logs.GetLogger().Errorf("failed to query task, task ids: %v, error: %v", group.Ids, err)
+			logs.GetLogger().Errorf("failed to query task, task ids: %v, error: %v", group.Uuids, err)
 			continue
 		}
 

--- a/internal/computing/ubi_service.go
+++ b/internal/computing/ubi_service.go
@@ -1719,6 +1719,7 @@ func GetCpBalance() {
 		SequencerBalance: roundToSixDecimal(sequencerBalance),
 	}
 	cpBalanceEntity, err := NewCpBalanceService().GetCpBalance(cpAccountAddress)
+	fmt.Printf("cpBalanceEntity: %v, err: %v", cpBalanceEntity, err)
 	if err != nil || cpBalanceEntity == nil {
 		err = NewCpBalanceService().SaveCpBalance(cpBalance)
 	} else {

--- a/internal/models/entitys.go
+++ b/internal/models/entitys.go
@@ -31,7 +31,8 @@ func UbiTaskTypeStr(typeInt int) string {
 }
 
 const (
-	TASK_RECEIVED_STATUS = iota + 1
+	TASK_REJECTED_STATUS = iota
+	TASK_RECEIVED_STATUS
 	TASK_RUNNING_STATUS
 	TASK_SUBMITTED_STATUS
 	TASK_FAILED_STATUS
@@ -48,6 +49,8 @@ const (
 func TaskStatusStr(status int) string {
 	var statusStr string
 	switch status {
+	case TASK_REJECTED_STATUS:
+		statusStr = "rejected"
 	case TASK_RECEIVED_STATUS:
 		statusStr = "received"
 	case TASK_RUNNING_STATUS:

--- a/internal/models/resources.go
+++ b/internal/models/resources.go
@@ -37,6 +37,7 @@ type GpuDetail struct {
 	FbMemoryUsage Common    `json:"fb_memory_usage"`
 	OriginalName  string    `json:"original_name"`
 	Index         string    `json:"index"`
+	Guid          string    `json:"guid"`
 }
 
 type Common struct {

--- a/ubi/README.md
+++ b/ubi/README.md
@@ -29,7 +29,7 @@ curl -fsSL https://raw.githubusercontent.com/swanchain/go-computing-provider/rel
 ## Install ECP and Init CP Account
 - Download `computing-provider`
 ```bash
-wget https://github.com/swanchain/go-computing-provider/releases/download/v1.0.1/computing-provider
+wget https://github.com/swanchain/go-computing-provider/releases/download/v1.0.2/computing-provider
 ```
 
 - Initialize ECP repo


### PR DESCRIPTION
* Synchronize mining status from ubi engine
* Add `rejected` status when receiving ubi task
* Save the log files within the specified time locally, located at <CP_REPO>/logs/<job_uuid>/container.log.
   - add config `[API].ClearLogDuration = 24`, cp can control when to clean up the logs
* Update `filswan/resource-exporter` version to v11.3.2.